### PR TITLE
Disable/Change Walk To XY Click Delay

### DIFF
--- a/Patches/DisableWalkToDelay.qs
+++ b/Patches/DisableWalkToDelay.qs
@@ -1,0 +1,34 @@
+//============================================================//
+// Patch Functions wrapping over ChangeWalkToDelay function                           //
+//============================================================//
+
+function DisableWalkToDelay() {
+  return ChangeWalkToDelay(0);
+}
+
+function SetWalkToDelay() {
+  return ChangeWalkToDelay(exe.getUserInput("$walkDelay", XTYPE_WORD, "Number Input", "Enter the new walk delay(0-1000) - snaps to closest valid value", 40, 0, 1000));
+}
+
+//#######################################################
+//# Purpose: Find the walk delay and replace it with the value specified.  #
+//#######################################################
+
+function ChangeWalkToDelay(value) {
+
+  //Step 1a - Find the delay.
+  var code =
+    "81 C1 58 02 00 00" //ADD ECX,00000258   ;  600ms
+  + " 3B C1"       //CMP EAX,ECX
+  ;
+
+  //Step 1a - Find the code offset
+  var offset = exe.findCode(code, PTYPE_HEX, false);
+  if (offset === -1)
+    return "Failed in Step 1 - Walk Delay Code not found.";
+  
+  //Step 2 - Replace the value
+  exe.replace(offset + 2, value.packToHex(4) , PTYPE_HEX);
+
+  return true;
+}

--- a/Patches/_patchlist.qs
+++ b/Patches/_patchlist.qs
@@ -345,3 +345,13 @@ registerPatch(223, "MoveItemCountUpwards", "Move Item Count Upwards [Experimenta
 //registerPatch(224, "IncreaseNpcIDs", "Increase NPC Ids [Experimental]", "Custom", 0, "Neo", "Increase the Loaded NPC IDs to include 10K+ range IDs. Limits are configurable", false);
 
 registerPatch(225, "ShowRegisterButton", "Show Register Button", "Custom", 0, "Neo", "Makes the client always show register button on Login Window for all Langtypes. Clicking the button will open <registrationweb> from clientinfo and closes the client.", false);
+
+//======================================//
+// Delay Patches                                                         //
+//======================================//
+
+registerGroup(30, "WalkToDelay", true);
+
+registerPatch( 300, "DisableWalkToDelay", "Disable Walk To Delay.", "Fix", 30, "MegaByte", "Will have a quicker response to walking clicks. But client may likely send more/duplicated packets.", false);
+
+registerPatch( 301, "SetWalkToDelay", "Change Walk To Delay.", "Fix", 30, "MegaByte", "Can have a quicker response to walking clicks. But client may likely send more/duplicated packets.", false);


### PR DESCRIPTION
The delay was seriously annoying when players panic and click rapidly
their input was ignored.
Which lead to annoyed players and a quick death.

With this timer disabled or set to 40ms instead of 600ms then the game
play around walking feels a lot more responsive because it doesn't just
ignore a lot of rapid clicks.

This Walk Delay feature may have been implemented as a way to cut down
the data sent to the server when players click a lot.

A better way to do it would be to take the clicks in a short time slice,
or compare the location of clicks to not send duplicated packets.

At the end of the day the walktoxy packet is like 5 bytes in length.

To find this,

I found the packet ID of walktoxy (0x437)
Searched for it in the game.
Found a place it was moved into a structure
Looked above and found a call to timeGetTime
Which moved eax somewhere [esi+dx]
Found that address with a breakpoint and found what accessed it.
Found what was setting it on click.
timeGetTime()
add eax, 258

I think that is 600ms. Quite the delay.