### PR TITLE
Update ChangeWalkToDelay default to 150.

### DIFF
--- a/Patches/ChangeWalkToDelay.qs
+++ b/Patches/ChangeWalkToDelay.qs
@@ -7,7 +7,7 @@ function DisableWalkToDelay() {
 }
 
 function SetWalkToDelay() {
-  return ChangeWalkToDelay(exe.getUserInput("$walkDelay", XTYPE_WORD, "Number Input", "Enter the new walk delay(0-1000) - snaps to closest valid value", 40, 0, 1000));
+  return ChangeWalkToDelay(exe.getUserInput("$walkDelay", XTYPE_WORD, "Number Input", "Enter the new walk delay(0-1000) - snaps to closest valid value. Note: May cause to walk after instant cast skills if too low.", 150, 0, 1000));
 }
 
 //########################################################################


### PR DESCRIPTION
Too low of an option, and players will walk to where they cast an instant cast skill which is annoying.
Of course they could just hold shift but yeah.